### PR TITLE
Add Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "devise"
 
 gem "meta-tags"
 
+gem "kaminari"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.7.6)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.23.1)
@@ -312,6 +324,7 @@ DEPENDENCIES
   i18n
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   mysql2 (~> 0.5)
   puma (>= 5.0)

--- a/app/controllers/bodies_controller.rb
+++ b/app/controllers/bodies_controller.rb
@@ -4,10 +4,10 @@ class BodiesController < ApplicationController
     before_action :authorize_approved, only: %i[index new create edit update show edit update destroy]
 
     def index
-      @bodies = current_user.bodies
+      @bodies = current_user.bodies.page(params[:page]).per(3)
       @all_bodies = ::Body.joins(user: :teams)
       .where(teams: { id: current_user.teams.ids })
-      .distinct
+      .distinct.page(params[:page]).per(3)
     end
 
     def new

--- a/app/controllers/conditions_controller.rb
+++ b/app/controllers/conditions_controller.rb
@@ -4,10 +4,10 @@ class ConditionsController < ApplicationController
     before_action :authorize_approved, only: %i[index new create edit update show edit update destroy]
 
     def index
-      @conditions = current_user.conditions
+      @conditions = current_user.conditions.page(params[:page]).per(3)
       @all_conditions = Condition.joins(user: :teams)
       .where(teams: { id: current_user.teams.ids })
-      .distinct
+      .distinct.page(params[:page]).per(3)
     end
 
     def new

--- a/app/controllers/self_records_controller.rb
+++ b/app/controllers/self_records_controller.rb
@@ -4,10 +4,11 @@ class SelfRecordsController < ApplicationController
     before_action :authorize_approved, only: %i[index new create edit update show edit update destroy]
 
     def index
-      @self_records = current_user.self_records
+      @self_records = current_user.self_records.page(params[:page]).per(3)
       @all_records = SelfRecord.joins(user: :teams)
                              .where(teams: { id: current_user.teams.ids })
                              .distinct
+                             .page(params[:page]).per(3)
     end
 
     def new

--- a/app/controllers/training_menus_controller.rb
+++ b/app/controllers/training_menus_controller.rb
@@ -9,7 +9,7 @@ class TrainingMenusController < ApplicationController
       @training_menus = TrainingMenu.joins(user: :teams)
       .where(teams: { id: current_user.teams.ids })
       .distinct
-      .includes(:training_sets)
+      .includes(:training_sets).page(params[:page]).per(6)
     end
 
     def new

--- a/app/views/bodies/index.html.erb
+++ b/app/views/bodies/index.html.erb
@@ -73,6 +73,11 @@
       <p class="text-lg text-gray-600">現在、登録されている記録はありません。</p>
     </div>
   <% end %>
+  <% if current_user.role.coach? %>
+    <%= paginate @all_bodies %>
+  <% elsif current_user.role.athlete? %>
+    <%= paginate @bodies %>
+  <% end %>
   <!-- 新しい記録を追加 -->
   <div class="mt-6 text-center">
     <%= link_to '新しい記録を追加', new_body_path, class: "btn btn-primary btn-lg" %>

--- a/app/views/conditions/index.html.erb
+++ b/app/views/conditions/index.html.erb
@@ -77,6 +77,11 @@
       <p class="text-lg text-gray-600">現在、登録されている記録はありません。</p>
     </div>
   <% end %>
+  <% if current_user.role.coach? %>
+    <%= paginate @all_conditions %>
+  <% elsif current_user.role.athlete? %>
+    <%= paginate @conditions %>
+  <% end %>
   <!-- 新しい記録を追加 -->
   <div class="mt-6 text-center">
     <%= link_to '新しい記録を追加', new_condition_path, class: "btn btn-primary btn-lg" %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, class: "join-item btn", rel: 'next', remote: true %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", remote: true, rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<div class="join text-xs mt-8 mx-auto flex justify-center">
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, class: "join-item btn", rel: 'prev', remote: true %> 
+</span>

--- a/app/views/self_records/index.html.erb
+++ b/app/views/self_records/index.html.erb
@@ -71,6 +71,11 @@
       <p class="text-lg text-gray-600">現在、登録されている記録はありません。</p>
     </div>
   <% end %>
+  <% if current_user.role.coach? %>
+    <%= paginate @all_records %>
+  <% elsif current_user.role.athlete? %>
+    <%= paginate @self_records %>
+  <% end %>
   <!-- 新しい記録を追加 -->
   <div class="mt-6 text-center">
     <%= link_to '新しい記録を追加', new_self_record_path, class: "btn btn-primary btn-lg" %>

--- a/app/views/training_menus/index.html.erb
+++ b/app/views/training_menus/index.html.erb
@@ -40,6 +40,7 @@
       <p class="text-lg text-gray-600">現在、登録されている記録はありません。</p>
     </div>
   <% end %>
+  <%= paginate @training_menus %>
     <!-- 新しいメニュー作成 -->
   <div class="mt-10 text-center mb-6">
     <%= link_to '新しいメニューを作成', new_training_menu_path, class: "btn btn-primary btn-lg shadow-lg hover:shadow-xl transition-shadow duration-300" %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 3
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,3 +50,7 @@ ja:
       - :year
       - :month
       - :day
+  views:
+    pagination:
+      previous: "前へ"
+      next: "次へ"


### PR DESCRIPTION
## 1.目的・ゴール
### 概要
- 選手レコードページ・マイレコードページ・コンディションページ・フィジカルページ・トレーニングページにおいて、データが多くなった際に表示速度を維持し、ユーザーの操作性を向上させるためにページネーション機能を導入します。

### ゴール
- kaminariを使用して、ページネーション機能を実装する
- 一覧ページにページネーションリンクが表示されること
- ページごとに表示されるレコード数が制御され、動作確認ができる状態にする

## 2.作業内容
### Step1: gem 'kaminari'の導入
- Gemfileにkaminariを追加し、インストールを実行

### Step2: コントローラーの設定
- 各Controllerにおいて、indexアクションをデータをページネーションするように設定する。

### Step3: configの設定
- config/initializers/kaminari_config.rbにおいて、1ページあたりの表示件数を設定

### Step4: ビューの設定
- 各index.html.erbにおいて、ページネーションを表示させたい箇所にpaginateヘルパー「<%= paginate 〇〇 %>」を記述します。

### Step5: ページネーションのカスタマイズ
- Tailwind CSSのテンプレートとdaisyUIのコンポーネントを利用し、好みのページネーションをカスタマイズします。

## 確認事項
- [x] ページネーションリンクが正しく表示されているか
- [x] 1ページに表示される件数が指定通り制限されているか
- [x] 次ページ、前ページ、特定ページへのリンクが動作するか
- [x] 空の場合もエラーハンドリングされているか