### PR TITLE
FixDockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,11 @@ COPY . .
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/
 
-# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+# Precompile assets
+ARG RAILS_MASTER_KEY
+ENV RAILS_MASTER_KEY=${RAILS_MASTER_KEY}
+
+RUN ./bin/rails assets:precompile
 
 RUN rm -rf node_modules
 


### PR DESCRIPTION
- [ ] DockerfileにてSECRET_KEY_BASE_DUMMYの代わりにRAILS_MASTER_KEYへ変更