### PR TITLE
FixConfirmationEmail

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: "your-production-domain.com" }
+  config.action_mailer.default_url_options = { host: "swimfirst.net", protocol: "https" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
@@ -88,7 +88,8 @@ Rails.application.configure do
     authentication: "plain",
     enable_starttls_auto: true,
     user_name: Rails.application.credentials.dig(:gmail, :user_name),
-    password: Rails.application.credentials.dig(:gmail, :app_password)
+    password: Rails.application.credentials.dig(:gmail, :app_password),
+    openssl_verify_mode: "none"
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
- 本番環境に以下を設定  
config.action_mailer.default_url_options = { host: "swimfirst.net", protocol: "https" }