### PR TITLE
FixModalandRecord

### DIFF
--- a/app/javascript/modal_control.js
+++ b/app/javascript/modal_control.js
@@ -2,9 +2,10 @@ document.addEventListener("DOMContentLoaded", function() {
   const csrfToken = document.querySelector("meta[name='csrf-token']")?.content;
 
   if (window.showModal && window.modalType) {
-    Alpine.store(window.modalType, true);
-    
-    console.log("モーダルを開きます:", window.modalType);
+    setTimeout(() => { // 遷移後の処理を遅延させる
+      Alpine.store(window.modalType, true);
+      console.log("モーダルを開きます:", window.modalType);
+    }, 100); // 100ms の遅延を入れる
 
     fetch("/hide_modal", {
       method: "POST",
@@ -12,15 +13,13 @@ document.addEventListener("DOMContentLoaded", function() {
         "X-CSRF-Token": csrfToken,
         "Content-Type": "application/json"
       }
-    })
-    .then(response => {
+    }).then(response => {
       if (!response.ok) {
         console.error("fetch('/hide_modal') に失敗:", response.status);
       } else {
         console.log("fetch('/hide_modal') が成功しました");
       }
-    })
-    .catch(error => {
+    }).catch(error => {
       console.error("fetch('/hide_modal') 実行時のエラー:", error);
     });
   }

--- a/app/javascript/record_input.js
+++ b/app/javascript/record_input.js
@@ -1,26 +1,31 @@
 document.addEventListener("DOMContentLoaded", () => {
   const recordInput = document.getElementById("record_input");
   const hiddenInput = document.getElementById("record_hidden");
-  
-  if (!recordInput || !hiddenInput) return; // 要素がない場合は処理しない
-  
-  recordInput.addEventListener("input", (event) => {
-    const value = event.target.value.trim();
-  
-    // 正規表現で "1'27"28" のような形式をキャッチ
+  const form = document.querySelector("form");
+
+  if (!recordInput || !hiddenInput || !form) return;
+
+  const updateHiddenInput = () => {
+    const value = recordInput.value.trim();
     const match = value.match(/^(\d*)'*(\d{1,2})"(\d{1,2})$/);
     if (match) {
       const minutes = parseInt(match[1] || "0", 10);
       const seconds = parseInt(match[2], 10);
       const milliseconds = parseInt(match[3], 10);
       const totalMilliseconds = (minutes * 60 + seconds) * 100 + milliseconds;
-  
-      // hidden input に変換後のデータを入れる
       hiddenInput.value = totalMilliseconds;
     } else {
-      // 無効な入力時は hidden フィールドを空にする
       hiddenInput.value = "";
     }
+  };
+
+  // スマホ対策: `input`, `change`, `blur` の全てで発火させる
+  recordInput.addEventListener("input", updateHiddenInput);
+  recordInput.addEventListener("change", updateHiddenInput);
+  recordInput.addEventListener("blur", updateHiddenInput);
+
+  // フォーム送信時に hiddenInput の値を確実にセット
+  form.addEventListener("submit", () => {
+    updateHiddenInput();
   });
 });
-  

--- a/app/views/self_records/new.html.erb
+++ b/app/views/self_records/new.html.erb
@@ -23,7 +23,9 @@
       <!-- 記録（入力） -->
       <div class="form-control">
         <%= form.label :record, '記録 (例: 1\'10"10)', class: "label font-bold text-gray-700" %>
-        <%= form.text_field :record, id: "record_input", class: "input input-bordered w-full" %>
+        <%= form.text_field :record, id: "record_input", 
+               class: "input input-bordered w-full",
+               autocomplete: "off", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
         <%= form.hidden_field :record, id: "record_hidden" %>
       </div>
 


### PR DESCRIPTION
- ページ遷移後、モーダルが一瞬チラつく現象を解消
  - modalのjsコードの処理を少し遅らせることで、本来の順序で処理させた
- レコードページにてスマホで記録が保存されなかった部分を解消